### PR TITLE
css: Move `bootstrap-focus-style` from id to class

### DIFF
--- a/static/templates/invite_user.hbs
+++ b/static/templates/invite_user.hbs
@@ -55,7 +55,7 @@
                         {{> help_link_widget link="/help/roles-and-permissions" }}
                     </label>
                     <div>
-                        <select id="invite_as bootstrap-focus-style" class="invite-as">
+                        <select id="invite_as" class="invite-as bootstrap-focus-style">
                             <option name="invite_as" value="{{ invite_as_options.guest.code }}">{{t "Guests" }}</option>
                             <option name="invite_as" selected="selected" value="{{ invite_as_options.member.code }}">{{t "Members" }}</option>
                             {{#if is_admin}}


### PR DESCRIPTION
The commit af36e9f added a bug that breaks new user invite. The CSS class ` bootstrap-focus-style` was added to `id` hence breaking the value extraction.

Fixes: #24249

**Screenshots and screen captures:**
![image](https://user-images.githubusercontent.com/5552382/215985486-25cb1143-7999-4ce5-a449-8db9c77fb32f.png)

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
